### PR TITLE
grab new upstream migrations via rake shipit:install:migrations

### DIFF
--- a/db/migrate/20190903173525_add_lock_author_id_to_commits.shipit.rb
+++ b/db/migrate/20190903173525_add_lock_author_id_to_commits.shipit.rb
@@ -1,0 +1,6 @@
+# This migration comes from shipit (originally 20190502020249)
+class AddLockAuthorIdToCommits < ActiveRecord::Migration[5.2]
+  def change
+    add_column(:commits, :lock_author_id, :integer, limit: 4)
+  end
+end


### PR DESCRIPTION
> Updating an existing installation
> If you locked the gem to a specific version in your Gemfile, update it there.
> Update the shipit-engine gem with bundle update shipit-engine.
> Install new migrations with rake shipit:install:migrations db:migrate.
https://github.com/Shopify/shipit-engine#i-installation--setup