### PR TITLE
Fix livenessProbe using sidekiq_alive gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'sidekiq'
+gem 'sidekiq_alive'
 gem 'shipit-engine', github: 'bcgov/cas-shipit-engine'
 gem 'redis-rails'
 gem 'kubernetes-deploy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,7 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    mustermann (1.0.3)
     netrc (0.11.0)
     nio4r (2.5.1)
     nokogiri (1.10.4)
@@ -343,11 +344,19 @@ GEM
       rack (>= 1.5.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
+    sidekiq_alive (2.0.0)
+      sidekiq
+      sinatra
     signet (0.11.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
+    sinatra (2.0.7)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.7)
+      tilt (~> 2.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -419,6 +428,7 @@ DEPENDENCIES
   selenium-webdriver
   shipit-engine!
   sidekiq
+  sidekiq_alive
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/openshift/deploy/deploymentconfig/shipit.yml
+++ b/openshift/deploy/deploymentconfig/shipit.yml
@@ -98,6 +98,14 @@ objects:
               command:
                 - /usr/bin/env
               image: ${OC_REGISTRY}/${OC_PROJECT}/${PREFIX}shipit:${GIT_SHA1}
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                      - /usr/bin/env
+                      - bash
+                      - "-c"
+                      - bundle exec sidekiqctl quiet
               <<: *envDefaults
               imagePullPolicy: IfNotPresent
               name: ${PREFIX}shipit-worker

--- a/openshift/deploy/deploymentconfig/shipit.yml
+++ b/openshift/deploy/deploymentconfig/shipit.yml
@@ -108,18 +108,29 @@ objects:
                 requests:
                   cpu: 500m
                   memory: 256Mi
-              livenessProbe:
-                exec:
-                  command:
-                    - /usr/bin/env
-                    - bash
-                    - '-c'
-                    - '"ps ax | grep -v grep | grep sidekiq"'
+              ports:
+                - containerPort: 7433
+                  protocol: TCP
+              readinessProbe:
                 failureThreshold: 3
-                initialDelaySeconds: 120
+                httpGet:
+                  path: /
+                  port: 7433
+                  scheme: HTTP
+                initialDelaySeconds: 30
                 periodSeconds: 10
                 successThreshold: 1
                 timeoutSeconds: 1
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /
+                  port: 7433
+                  scheme: HTTP
+                initialDelaySeconds: 600
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 30
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
           dnsPolicy: ClusterFirst


### PR DESCRIPTION
Shipit is currently unstable as the `livenessProbe` for sidekiq is malformed. As a result, the pod is being regularly killed by openshift in an attempt to restore service health.