### PR TITLE
only interact with Pathfinder on develop and master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,11 +135,18 @@ workflows:
       - verify:
           requires:
             - bundle
+
       - oc_lint:
           context: cas-pipeline
-      - oc_build:
           requires:
             - test
             - verify
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+      - oc_build:
+          requires:
             - oc_lint
           context: cas-pipeline


### PR DESCRIPTION
this cuts down on the pathfinder resources used by only building on `master` and `develop` branches