### PR TITLE
sidekiq concurrency should be greater than 1

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,6 @@
-:concurrency: 1
+:concurrency: 5
+production:
+  :concurrency: 25
 :queues:
   - default
   - deploys


### PR DESCRIPTION
the livenessProbe is killing the workers pool before they're done because we only have one worker