### PR TITLE
feat: use separate dc for web and worker for independent pod control

### DIFF
--- a/openshift/deploy/deploymentconfig/shipit-web.yml
+++ b/openshift/deploy/deploymentconfig/shipit-web.yml
@@ -41,24 +41,24 @@ objects:
   - apiVersion: v1
     kind: DeploymentConfig
     metadata:
-      name: ${PREFIX}shipit
+      name: ${PREFIX}shipit-web
     spec:
       replicas: 1
       selector:
-        name: ${PREFIX}shipit
+        name: ${PREFIX}shipit-web
       strategy:
         type: Rolling
       template:
         metadata:
           labels:
-            name: ${PREFIX}shipit
+            name: ${PREFIX}shipit-web
         spec:
           restartPolicy: Always
           containers:
-            - image: ${OC_REGISTRY}/${OC_PROJECT}/${PREFIX}shipit:${GIT_SHA1}
+            - name: ${PREFIX}shipit-web
+              image: ${OC_REGISTRY}/${OC_PROJECT}/${PREFIX}shipit:${GIT_SHA1}
               <<: *envDefaults
               imagePullPolicy: IfNotPresent
-              name: ${PREFIX}shipit-web
               ports:
                 - containerPort: 8080
                   protocol: TCP
@@ -89,56 +89,6 @@ objects:
                 requests:
                   cpu: 500m
                   memory: 512Mi
-              terminationMessagePath: /dev/termination-log
-              terminationMessagePolicy: File
-            - args:
-                - bash
-                - "-c"
-                - bundle exec sidekiq -C config/sidekiq.yml
-              command:
-                - /usr/bin/env
-              image: ${OC_REGISTRY}/${OC_PROJECT}/${PREFIX}shipit:${GIT_SHA1}
-              lifecycle:
-                preStop:
-                  exec:
-                    command:
-                      - /usr/bin/env
-                      - bash
-                      - "-c"
-                      - bundle exec sidekiqctl quiet
-              <<: *envDefaults
-              imagePullPolicy: IfNotPresent
-              name: ${PREFIX}shipit-worker
-              resources:
-                limits:
-                  cpu: "1"
-                  memory: 512Mi
-                requests:
-                  cpu: 500m
-                  memory: 256Mi
-              ports:
-                - containerPort: 7433
-                  protocol: TCP
-              readinessProbe:
-                failureThreshold: 3
-                httpGet:
-                  path: /
-                  port: 7433
-                  scheme: HTTP
-                initialDelaySeconds: 30
-                periodSeconds: 10
-                successThreshold: 1
-                timeoutSeconds: 1
-              livenessProbe:
-                failureThreshold: 3
-                httpGet:
-                  path: /
-                  port: 7433
-                  scheme: HTTP
-                initialDelaySeconds: 600
-                periodSeconds: 10
-                successThreshold: 1
-                timeoutSeconds: 30
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
           dnsPolicy: ClusterFirst

--- a/openshift/deploy/deploymentconfig/shipit-worker.yml
+++ b/openshift/deploy/deploymentconfig/shipit-worker.yml
@@ -1,0 +1,115 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+
+parameters:
+  - description: Prefix to prepend to object name.
+    displayName: Prefix
+    name: PREFIX
+    required: true
+  - description: SHA1 of git revision to be deployed.
+    displayName: Git SHA1
+    name: GIT_SHA1
+    required: true
+  - description: Openshift project name
+    displayName: Project
+    name: OC_PROJECT
+    required: true
+  - description: Openshift registry URL
+    displayName: Registry
+    name: OC_REGISTRY
+    required: true
+  - description: Postgres Database Password
+    displayName: Postgres Database Password
+    name: POSTGRES_PASSWORD
+
+
+envDefaults: &envDefaults
+  env:
+    - name: RAILS_ENV
+      value: production
+    - name: DATABASE_URL
+      value: postgres://shipit:${POSTGRES_PASSWORD}@cas-shipit-postgres-master:5432/shipit
+    - name: RAILS_MASTER_KEY
+      valueFrom:
+        secretKeyRef:
+          key: RAILS_MASTER_KEY
+          name: ${PREFIX}shipit-worker
+    - name: RAILS_SERVE_STATIC_FILES
+      value: "true"
+
+objects:
+  - apiVersion: v1
+    kind: DeploymentConfig
+    metadata:
+      name: ${PREFIX}shipit-worker
+    spec:
+      replicas: 1
+      selector:
+        name: ${PREFIX}shipit-worker
+      strategy:
+        type: Rolling
+      template:
+        metadata:
+          labels:
+            name: ${PREFIX}shipit-worker
+        spec:
+          restartPolicy: Always
+          containers:
+            - name: ${PREFIX}shipit-worker
+              image: ${OC_REGISTRY}/${OC_PROJECT}/${PREFIX}shipit:${GIT_SHA1}
+              command:
+                - /usr/bin/env
+              args:
+                - bash
+                - "-c"
+                - bundle exec sidekiq -C config/sidekiq.yml
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                      - /usr/bin/env
+                    args:
+                      - bash
+                      - "-c"
+                      - bundle exec sidekiqctl quiet
+              <<: *envDefaults
+              imagePullPolicy: IfNotPresent
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 512Mi
+                requests:
+                  cpu: 500m
+                  memory: 256Mi
+              ports:
+                - containerPort: 7433
+                  protocol: TCP
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /
+                  port: 7433
+                  scheme: HTTP
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 1
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /
+                  port: 7433
+                  scheme: HTTP
+                initialDelaySeconds: 600
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 30
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          serviceAccount: cas-shipit
+          serviceAccountName: cas-shipit
+          terminationGracePeriodSeconds: 30


### PR DESCRIPTION
Hoping this will also resolve readinessProbe and livenessProbe issues with the worker.
<img width="413" alt="Screen Shot 2020-05-28 at 9 57 47 AM (1)" src="https://user-images.githubusercontent.com/597920/83177272-9ebdbd80-a0d3-11ea-9c74-49b9627f5fea.png">
