### PR TITLE
bugfix: route should point to new shipit-web dc

### DIFF
--- a/openshift/deploy/route/shipit.yml
+++ b/openshift/deploy/route/shipit.yml
@@ -19,7 +19,7 @@ objects:
     spec:
       host: ${PREFIX}shipit.pathfinder.gov.bc.ca
       port:
-        targetPort: ${PREFIX}shipit
+        targetPort: ${PREFIX}shipit-web
       tls:
         termination: edge
         insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
the `cas-shipit` dc was split to `cas-shipit-web` and `cas-shipit-worker` in #66 but the route was not updated