### PR TITLE
bugfix: service should point to new shipit-web dc

### DIFF
--- a/openshift/deploy/service/shipit.yml
+++ b/openshift/deploy/service/shipit.yml
@@ -19,7 +19,7 @@ objects:
           protocol: TCP
           targetPort: 8080
       selector:
-        name: ${PREFIX}shipit
+        name: ${PREFIX}shipit-web
       sessionAffinity: None
       type: ClusterIP
     status:


### PR DESCRIPTION
the `cas-shipit` dc was split to `cas-shipit-web` and `cas-shipit-worker` in #66 but the route was not updated

replaces #68