### PR TITLE
bugfix: use the same RAILS_MASTER_KEY secret everywhere

### DIFF
--- a/openshift/deploy/deploymentconfig/shipit-worker.yml
+++ b/openshift/deploy/deploymentconfig/shipit-worker.yml
@@ -33,7 +33,7 @@ envDefaults: &envDefaults
       valueFrom:
         secretKeyRef:
           key: RAILS_MASTER_KEY
-          name: ${PREFIX}shipit-worker
+          name: ${PREFIX}shipit
     - name: RAILS_SERVE_STATIC_FILES
       value: "true"
 


### PR DESCRIPTION
resolves attempt to read nonexistent `cas-shipit-worker` secret introduced in #66