### PR TITLE
chore: CVE-2019-10744

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    lodash-rails (4.6.1)
+    lodash-rails (4.17.21)
       railties (>= 3.1)
     loofah (2.9.1)
       crass (~> 1.0.2)


### PR DESCRIPTION
This triggers a warning on `bundle install` since shipit-engine is not setup to accept versions of `lodash-rails` beyond 4.6.x
