### PR TITLE
Chore/222 crunchdb pgo migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,20 @@ lint: whoami
 	@helm dep up helm/cas-shipit
 	@helm template cas-shipit helm/cas-shipit -f secret-values.example.yaml --validate -n $(OC_PROJECT)
 
+.PHONY: install_pgo_cluster
+install_pgo_cluster:
+	@set -euo pipefail;
+	helm repo add cas-postgres https://bcgov.github.io/cas-postgres/;
+	helm repo update;
+
+	helm upgrade --install --atomic --timeout 3000s \
+		--namespace $(OC_PROJECT) \
+		--values ./helm/cas-shipit-postgres-values.yaml \
+		cas-shipit-db cas-postgres/cas-postgres;
+
+# TODO: Remove cas-postgres and add PG-Cluster deployment
 .PHONY: install
-install: whoami
+install: whoami install_pgo_cluster
 	@helm repo add cas-postgres https://bcgov.github.io/cas-postgres/
 	@helm repo add bitnami https://charts.bitnami.com/bitnami
 	@helm dep build helm/cas-shipit

--- a/helm/cas-shipit-postgres-cluster/values.yaml
+++ b/helm/cas-shipit-postgres-cluster/values.yaml
@@ -1,0 +1,42 @@
+# Values file to be passed to a deployment of https://github.com/bcgov/cas-postgres/tree/develop/helm/cas-postgres-cluster
+
+# dev, test, prod
+environment: prod
+
+postgresCluster:
+  postgresVersion: 17
+  postgres:
+    replicaCount: 3
+  pgbouncer:
+    replicaCount: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+  # The "users" value(s) is passed to the crunch postgres operator to create the database.
+  # See http://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/basic-setup/user-management
+  users:
+    - name: postgres
+      password:
+        type: AlphaNumeric
+      databases:
+        - cas_shipit
+    - name: shipit
+      databases:
+        - cas_shipit
+      password:
+        type: AlphaNumeric
+
+gcsBackups:
+  enable: true
+  # Needs to match the "namespace_apps" value in the terraform provisioning chart.
+  # example syntax: bucketName
+  bucketName: shipit-pgo-bkup
+
+terraform-bucket-provision:
+  terraform:
+    # example syntax: '["bucketName"]'
+    namespace_apps: '["shipit-pgo-bkup"]'
+    # !important: unique for the deployment
+    workspace: shipit-pgo

--- a/helm/cas-shipit-postgres-cluster/values.yaml
+++ b/helm/cas-shipit-postgres-cluster/values.yaml
@@ -13,6 +13,9 @@ postgresCluster:
     requests:
       cpu: 100m
       memory: 256Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
 
   # The "users" value(s) is passed to the crunch postgres operator to create the database.
   # See http://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/basic-setup/user-management

--- a/helm/cas-shipit-postgres-cluster/values.yaml
+++ b/helm/cas-shipit-postgres-cluster/values.yaml
@@ -8,7 +8,7 @@ postgresCluster:
   postgres:
     replicaCount: 3
   pgbouncer:
-    replicaCount: 2
+    replicaCount: 1
   resources:
     requests:
       cpu: 100m
@@ -21,10 +21,10 @@ postgresCluster:
       password:
         type: AlphaNumeric
       databases:
-        - cas_shipit
+        - postgres
     - name: shipit
       databases:
-        - cas_shipit
+        - postgres
       password:
         type: AlphaNumeric
 

--- a/helm/cas-shipit-postgres-cluster/values.yaml
+++ b/helm/cas-shipit-postgres-cluster/values.yaml
@@ -27,6 +27,7 @@ postgresCluster:
         - postgres
       password:
         type: AlphaNumeric
+      options: 'SUPERUSER'
 
 gcsBackups:
   enable: true

--- a/helm/cas-shipit-postgres-cluster/values.yaml
+++ b/helm/cas-shipit-postgres-cluster/values.yaml
@@ -32,11 +32,11 @@ gcsBackups:
   enable: true
   # Needs to match the "namespace_apps" value in the terraform provisioning chart.
   # example syntax: bucketName
-  bucketName: shipit-pgo-bkup
+  bucketName: shipit-pg-bup
 
 terraform-bucket-provision:
   terraform:
     # example syntax: '["bucketName"]'
-    namespace_apps: '["shipit-pgo-bkup"]'
+    namespace_apps: '["shipit-pg-bup"]'
     # !important: unique for the deployment
     workspace: shipit-pgo

--- a/helm/cas-shipit-postgres-cluster/values.yaml
+++ b/helm/cas-shipit-postgres-cluster/values.yaml
@@ -30,8 +30,6 @@ postgresCluster:
         - postgres
       password:
         type: AlphaNumeric
-      options: 'SUPERUSER'
-
 gcsBackups:
   enable: true
   # Needs to match the "namespace_apps" value in the terraform provisioning chart.

--- a/helm/cas-shipit/Chart.lock
+++ b/helm/cas-shipit/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 19.1.3
-digest: sha256:a0adbde0ed236eeffedcb717df5321df72eb9be06ed51552d937f74f7c2a101b
-generated: "2024-04-29T10:49:45.162673-07:00"
+- name: patroni-migration
+  repository: https://bcgov.github.io/cas-postgres/
+  version: 1.0.1
+digest: sha256:aa784ba08ebf492ff94c0f4fa2cde7f325848c5f742d528a28d3c5362ea8b8b7
+generated: "2025-07-15T12:17:52.193980815-06:00"

--- a/helm/cas-shipit/Chart.yaml
+++ b/helm/cas-shipit/Chart.yaml
@@ -11,3 +11,6 @@ dependencies:
   - name: redis
     version: 19.1.3
     repository: https://charts.bitnami.com/bitnami
+  - name: patroni-migration
+    version: 1.0.1
+    repository: https://bcgov.github.io/cas-postgres/

--- a/helm/cas-shipit/Chart.yaml
+++ b/helm/cas-shipit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cas-shipit
 description: A Helm chart for cas-shipit
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: 0.39.0
 dependencies:
   - name: cas-postgres

--- a/helm/cas-shipit/templates/_helpers.tpl
+++ b/helm/cas-shipit/templates/_helpers.tpl
@@ -107,16 +107,29 @@ Environment variables required by the shipit container
       name: {{ include "cas-shipit.fullname" . }}
       key: github_oauth_team
 - name: PGHOST
-  value: {{ include "cas-shipit.fullname" . }}-patroni
-- name: PGUSER
-  value: postgres
-- name: PGDATABASE
-  value: postgres
-- name: PGPASSWORD
+  value: null
   valueFrom:
     secretKeyRef:
-      name: {{ include "cas-shipit.fullname" . }}-patroni
-      key: password-superuser
+      key: pgbouncer-host
+      name: {{ .Values.database.releaseName }}-{{ .Values.database.chartName }}-pguser-{{ .Values.database.user}}
+- name: PGUSER
+  value: null
+  valueFrom:
+    secretKeyRef:
+      key: user
+      name: {{ .Values.database.releaseName }}-{{ .Values.database.chartName }}-pguser-{{ .Values.database.user}}
+- name: PGDATABASE
+  value: null
+  valueFrom:
+    secretKeyRef:
+      key: dbname
+      name: {{ .Values.database.releaseName }}-{{ .Values.database.chartName }}-pguser-{{ .Values.database.user}}
+- name: PGPASSWORD
+  value: null
+  valueFrom:
+    secretKeyRef:
+      key: password
+      name: {{ .Values.database.releaseName }}-{{ .Values.database.chartName }}-pguser-{{ .Values.database.user}}
 - name: AIRFLOW_NAMESPACE_PREFIX
   valueFrom:
     secretKeyRef:

--- a/helm/cas-shipit/templates/cronjob/shipit-hourly.yml
+++ b/helm/cas-shipit/templates/cronjob/shipit-hourly.yml
@@ -37,4 +37,4 @@ spec:
           activeDeadlineSeconds: 3600
   schedule: 0 */1 * * *
   successfulJobsHistoryLimit: 1
-  suspend: false
+  suspend: true

--- a/helm/cas-shipit/templates/cronjob/shipit-minutely.yml
+++ b/helm/cas-shipit/templates/cronjob/shipit-minutely.yml
@@ -36,4 +36,4 @@ spec:
           activeDeadlineSeconds: 300
   schedule: "*/5 * * * *"
   successfulJobsHistoryLimit: 1
-  suspend: false
+  suspend: true

--- a/helm/cas-shipit/templates/networksecuritypolicy/postgres-cluster-access.yaml
+++ b/helm/cas-shipit/templates/networksecuritypolicy/postgres-cluster-access.yaml
@@ -1,0 +1,17 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "cas-shipit.fullname" . }}-postgres-cluster-access
+  labels: {{ include "cas-shipit.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Values.database.releaseName }}
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              release: {{ include "cas-shipit.name" . }}
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: {{ include "cas-shipit.name" . }}

--- a/helm/cas-shipit/values.yaml
+++ b/helm/cas-shipit/values.yaml
@@ -27,7 +27,7 @@ shipit:
   web:
     puma_workers: 4
 
-databaseCluster:
+database:
   releaseName: cas-shipit-db
   chartName: cas-postgres-cluster
   user: shipit
@@ -90,15 +90,15 @@ patroni-migration:
     tag: 17
 
   deployment:
-    name: cas-shipit
     sourceReleaseName: cas-shipit
+    name: cas-shipit-web
     targetReleaseName: cas-shipit-db
     originalReplicaCount: 3
 
   from:
     # Assuming all database information will be in the same secret
     # Pass either the secret's key or the specific value
-    secretName: cas-ggircs-patroni
+    secretName: cas-shipit-patroni
     hostSecretKey: ~
     host: cas-shipit-patroni.0fad32-tools.svc.cluster.local
     passwordSecretKey: password-superuser

--- a/helm/cas-shipit/values.yaml
+++ b/helm/cas-shipit/values.yaml
@@ -27,6 +27,7 @@ shipit:
   web:
     puma_workers: 4
 
+# TODO: Remove this once PGO is deployed
 cas-postgres:
   patroni:
     resources:
@@ -77,3 +78,37 @@ redis:
     # We are providing our own secret as the redis chart regenerates the password with every deploy
     existingSecret: cas-shipit-redis
     existingSecretPasswordKey: redis-password
+
+patroni-migration:
+  migrationJob:
+    image: postgres
+    tag: 17
+
+  deployment:
+    name: cas-shipit
+    sourceReleaseName: cas-shipit
+    targetReleaseName: cas-shipit-db
+    originalReplicaCount: 3
+
+  from:
+    # Assuming all database information will be in the same secret
+    # Pass either the secret's key or the specific value
+    secretName: cas-ggircs-patroni
+    hostSecretKey: ~
+    host: cas-shipit-patroni.0fad32-tools.svc.cluster.local
+    passwordSecretKey: password-superuser
+    password: ~
+    portSecretKey: ~
+    port: 5432
+    userSecretKey: ~
+    user: postgres
+
+    # The name of the database to migrate
+    db: postgres
+
+  to:
+    # This is necessarily a PGO deployment
+    # superuser to migrate roles
+    superuserSecretName: cas-shipit-db-cas-postgres-cluster-pguser-postgres
+    # new owner of database to run own the migrated database
+    appuserSecretName: cas-shipit-db-cas-postgres-cluster-pguser-shipit

--- a/helm/cas-shipit/values.yaml
+++ b/helm/cas-shipit/values.yaml
@@ -62,7 +62,7 @@ redis:
     resources:
       limits:
         cpu: 250m
-        memory: 128Mi
+        memory: 512Mi
       requests:
         cpu: 30m
         memory: 64Mi
@@ -75,7 +75,7 @@ redis:
     resources:
       limits:
         cpu: 250m
-        memory: 128Mi
+        memory: 512Mi
       requests:
         cpu: 30m
         memory: 64Mi

--- a/helm/cas-shipit/values.yaml
+++ b/helm/cas-shipit/values.yaml
@@ -27,6 +27,11 @@ shipit:
   web:
     puma_workers: 4
 
+databaseCluster:
+  releaseName: cas-shipit-db
+  chartName: cas-postgres-cluster
+  user: shipit
+
 # TODO: Remove this once PGO is deployed
 cas-postgres:
   patroni:


### PR DESCRIPTION
Addresses #222. Migrates the DB to the Crunchy Operator.

## Changes 🚧

- Added deployment values for `cas-postgres/cas-postgres-cluster` Crunchy chart.
- Updated deployment script to include new chart.
- Added migration from old DB to new DB.
- Updated Shipit chart to look for new DB.
- Added network policy for new DB.

Note, `cas-shipit` only has a production deployment. This chart has been tested by deploying main to `-test`, installing the PGO, then upgrading the base deployment to this version. 